### PR TITLE
docs: Fix README to use /home/ instead of /root/

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Using either `docker` or `podman` will be fine. I like `podman` better, so
 examples are with podman.
 
 ```
-podman run jamesread/prometheus-gmail-exporter:latest -v ~/.prometheus-gmail-exporter/:/root/.prometheus-gmail-exporter/
+podman run -v ~/.prometheus-gmail-exporter/:/home/.prometheus-gmail-exporter/ jamesread/prometheus-gmail-exporter:latest 
 ```
 
 ## Building your own container image
 
 ```
 podman build . -t gmail-exporter
-podman run -v ~/.prometheus-gmail-exporter/:/root/.prometheus-gmail-exporter/ gmail-exporter Label_33
+podman run -v ~/.prometheus-gmail-exporter/:/home/.prometheus-gmail-exporter/ gmail-exporter Label_33
 ```
 
 ## Running via command line


### PR DESCRIPTION
Because that's where $HOME is in `FROM fedora:latest`  - at least in current v37; perhaps this changed at some point in the past.

PS: I've also flipped around the `-v` and the container name just so it's consistent and easier to read among both of your examples.