### PR TITLE
Fix shebang to use env instead of python3 directly

### DIFF
--- a/gmail-exporter.py
+++ b/gmail-exporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Checks gmail labels for unread messages and exposes the counts via prometheus.
 """


### PR DESCRIPTION
This avoids confusion with venv Python Virtual Environments.