### PR TITLE
Fix OAuth Login flow (fixes #10)

### DIFF
--- a/gmail-exporter.py
+++ b/gmail-exporter.py
@@ -51,7 +51,7 @@ def get_credentials():
         flow = InstalledAppFlow.from_client_secrets_file(args.clientSecretFile, SCOPES)
         flow.user_agent = 'prometheus-gmail-exporter'
 
-        credentials = flow.run_local_server(port=0, bind_addr = '0.0.0.0', host = args.oauthHost)
+        credentials = flow.run_local_server(port=9090, bind_addr = '0.0.0.0', host = args.oauthHost)
 
         logging.info("Storing credentials to %s", args.credentialsPath)
 
@@ -257,7 +257,7 @@ if __name__ == '__main__':
     parser.add_argument('--clientSecretFile', default=get_homedir_filepath('client_secret.json'))
     parser.add_argument('--credentialsPath', default=get_homedir_filepath('login_cookie.dat'))
     parser.add_argument("--updateDelaySeconds", type=int, default=300)
-    parser.add_argument("--oauthHost", type=str, default="example.com")
+    parser.add_argument("--oauthHost", type=str, default="localhost")
     parser.add_argument("--promPort", type=int, default=8080)
     parser.add_argument("--daemonize", action='store_true')
     parser.add_argument("--logLevel", type=int, default = 20)


### PR DESCRIPTION
Fix to 9090 instead of random port, and default to localhost instead of example.com.

Fixes #10 (for me)

@jamesread 